### PR TITLE
fix(#59): Include "empty" index.js in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run test && npm run clean && npm run build",
-    "clean": "rm -rf lib index.js && echo export default [] > index.js",
+    "clean": "rm -rf lib && echo export default [] > index.js",
     "build": "tsc -p src",
     "dev": "jest --watch",
     "lint": "tslint -p . && prettier --list-different \"{src,scripts,test}/**/*.{js,ts}\"",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "typings": "index.d.ts",
   "files": [
     "lib",
+    "index.js",
     "index.d.ts"
   ],
   "homepage": "https://github.com/ktsn/vue-auto-routing",
@@ -27,7 +28,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run test && npm run clean && npm run build",
-    "clean": "rm -rf lib index.js",
+    "clean": "rm -rf lib index.js && echo export default [] > index.js",
     "build": "tsc -p src",
     "dev": "jest --watch",
     "lint": "tslint -p . && prettier --list-different \"{src,scripts,test}/**/*.{js,ts}\"",


### PR DESCRIPTION
This PR drafts a solution for #59. Feel free to review and merge, if this fits your interest.

- During the `clean` npm script, generate the index.js file that
exports an empty array.
- Include index.js in the npm package.