### PR TITLE
feat: add option to specify output file (#72)

### DIFF
--- a/src/webpack-plugin.ts
+++ b/src/webpack-plugin.ts
@@ -6,7 +6,9 @@ import { generateRoutes, GenerateConfig } from 'vue-route-generator'
 
 const pluginName = 'VueAutoRoutingPlugin'
 
-interface Options extends GenerateConfig {}
+interface Options extends GenerateConfig {
+  outFile?: string
+}
 
 namespace VueAutoRoutingPlugin {
   export type AutoRoutingOptions = Options
@@ -20,7 +22,7 @@ class VueAutoRoutingPlugin {
   apply(compiler: Compiler) {
     const generate = () => {
       const code = generateRoutes(this.options)
-      const to = path.resolve(__dirname, '../index.js')
+      const to = this.options.outFile || path.resolve(__dirname, '../index.js')
 
       if (
         fs.existsSync(to) &&

--- a/test/__snapshots__/webpack-plugin.spec.ts.snap
+++ b/test/__snapshots__/webpack-plugin.spec.ts.snap
@@ -507,6 +507,37 @@ function users__id() {
 /******/ ]);"
 `;
 
+exports[`webpack plugin should write to custom output file if specified 1`] = `
+"function index() {
+  return import(/* webpackChunkName: \\"index\\" */ '@/pages/index.vue')
+}
+function users_foo() {
+  return import(/* webpackChunkName: \\"users-foo\\" */ '@/pages/users/foo.vue')
+}
+function users__id() {
+  return import(/* webpackChunkName: \\"users-id\\" */ '@/pages/users/_id.vue')
+}
+
+export default [
+  {
+    name: 'index',
+    path: '/',
+    component: index,
+  },
+  {
+    name: 'users-foo',
+    path: '/users/foo',
+    component: users_foo,
+  },
+  {
+    name: 'users-id',
+    path: '/users/:id?',
+    component: users__id,
+  },
+]
+"
+`;
+
 exports[`webpack plugin watches adding a page 1`] = `
 "/******/ (function(modules) { // webpackBootstrap
 /******/ 	// install a JSONP callback for chunk loading

--- a/test/webpack-plugin.spec.ts
+++ b/test/webpack-plugin.spec.ts
@@ -22,8 +22,11 @@ const compiler = (plugin: Plugin): webpack.Compiler => {
   })
 }
 
-const matchOutputWithSnapshot = () => {
-  const out = fse.readFileSync(resolve('./fixtures/out/main.js'), 'utf8')
+const matchOutputWithSnapshot = (path?: string) => {
+  const out = fse.readFileSync(
+    resolve(path || './fixtures/out/main.js'),
+    'utf8'
+  )
   expect(out).toMatchSnapshot()
 }
 
@@ -189,6 +192,19 @@ describe('webpack plugin', () => {
           matchOutputWithSnapshot()
           watching.close(done)
       }
+    })
+  })
+
+  it('should write to custom output file if specified', (done) => {
+    const plugin = new Plugin({
+      pages: resolve('fixtures/pages'),
+      outFile: resolve('fixtures/out/custom.js'),
+    })
+
+    compiler(plugin).run(() => {
+      expect(fse.existsSync(resolve('./fixtures/out/custom.js'))).toBeTruthy()
+      matchOutputWithSnapshot('fixtures/out/custom.js')
+      done()
     })
   })
 })


### PR DESCRIPTION
Fixes #72 

The solution allows to specify an absolute output file path. When specified, generated code will be written to that file, otherwise defaults to current behavior (this package's index.js file).